### PR TITLE
FIX Tweak getName to return only the name of the method

### DIFF
--- a/src/RegisterHandler.php
+++ b/src/RegisterHandler.php
@@ -109,7 +109,7 @@ class RegisterHandler implements RegisterHandlerInterface
 
     public function getName(): string
     {
-        return _t(__CLASS__ . '.NAME', 'Setup via authenticator app');
+        return _t(__CLASS__ . '.NAME', 'Authenticator app');
     }
 
     public function getDescription(): string


### PR DESCRIPTION
[Per the designs](https://projects.invisionapp.com/share/3PNSKZQYBJZ#/screens/322769156), the name of the method shouldn't contain 'Setup via' (and this also breaks usage of the name in other places, like the admin interface).