### PR TITLE
Update readme for SS_MFA_SECRET_KEY and snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ You will need to define an environment variable or PHP constant named `SS_MFA_SE
 which is used for encrypting the TOTP secret. The authentication method will not be available for use until this
 is correctly defined. This should be done in your `_ss_environment.php` file.
 
-Please note that existing registered TOTP methods for users will not be usable on environments with different values
-for `SS_MFA_SECRET_KEY` than they were registered in.
+If your hosting includes both a production and test environment (e.g UAT) and someone may restore a database snapshot
+from one environment to the other, then you'll want `SS_MFA_SECRET_KEY` to be the same on both environments.
+If `SS_MFA_SECRET_KEY` is different between environments, restoring a snapshot will requires previously authenticated
+users to have their registered authenticator app reset by an admin in the security section of the CMS.
 
 ### TOTP secret length
 


### PR DESCRIPTION
Update the paragraph in the readme why having SS_MFA_SECRET_KEY the same on two environments allows user authentication to still work after a snapshot restore