### PR TITLE
PHPCS Move strict_types to seperate lines

### DIFF
--- a/src/Method.php
+++ b/src/Method.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\TOTP;
 

--- a/src/RegisterHandler.php
+++ b/src/RegisterHandler.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\TOTP;
 

--- a/src/TOTPAware.php
+++ b/src/TOTPAware.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\TOTP;
 

--- a/src/VerifyHandler.php
+++ b/src/VerifyHandler.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace SilverStripe\TOTP;
 


### PR DESCRIPTION
Fix up PHPCS errors

This PR, was originally a fix for https://github.com/silverstripe/silverstripe-mfa/issues/378, though have moved logic to https://github.com/silverstripe/silverstripe-mfa/pull/401/files instead
