### PR TITLE
DEP PHP8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": "^7.3 || ^8.0",
         "silverstripe/mfa": "^4.0",
         "silverstripe/siteconfig": "^4.0",
-        "spomky-labs/otphp": "^9.1",
+        "spomky-labs/otphp": "^10",
         "paragonie/constant_time_encoding": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-totp-authenticator/issues/70

Have tested locally on php 8, things worked as expected

Changelog for dependency upgrade indicates that it's straightforward https://github.com/Spomky-Labs/otphp/blob/v10.0/doc/UPGRADE_v9-v10.md