### PR TITLE
FIX Loosen webauthn-authenticator constraint to fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ env:
     - REQUIRE_FRAMEWORKTEST="^0.4.2"
     - SS_MFA_SECRET_KEY=TEST123
     # Used by behat-extension LoginContext which expects a screen to choose either totp or webauthn when not skipping mfa
-    - REQUIRE_EXTRA="silverstripe/webauthn-authenticator:^4"
+    - REQUIRE_EXTRA="silverstripe/webauthn-authenticator:4.x-dev"


### PR DESCRIPTION
Travis is installing webauthn-authenticator 4.0.0-beta because the stable versions require a lower version of guzzle that conflicts with other dependencies (beta didn't have guzzle as a dependency).
e.g. see https://app.travis-ci.com/github/silverstripe/silverstripe-totp-authenticator/jobs/566544408

## Parent issue
- silverstripe/silverstripe-framework#10278