### PR TITLE
MNT Add missing translation strings to js src lang

### DIFF
--- a/client/lang/src/en.json
+++ b/client/lang/src/en.json
@@ -1,12 +1,12 @@
 {
-    "TOTPRegister.NEXT": "Next",
     "TOTPRegister.BACK": "Back",
-    "TOTPRegister.INTRO": "Verification codes are created by an app on your phone. ",
-    "TOTPRegister.OR": "Or",
-    "TOTPRegister.MANUAL": "Enter manually the following code into authentication app:",
     "TOTPRegister.HOW_TO_USE": "How to use authenticator app.",
-    "TOTPVerify.NEXT": "Next",
+    "TOTPRegister.INTRO": "Verification codes are created by an app on your phone. ",
+    "TOTPRegister.MANUAL": "Enter manually the following code into authentication app:",
+    "TOTPRegister.NEXT": "Next",
+    "TOTPRegister.OR": "Or",
+    "TOTPVerify.ENTER_CODE": "Enter {length}-digit code",
     "TOTPVerify.HOW_TO_USE": "How to use authenticator app.",
-    "TOTPVerify.VERIFY": "Use verification code from your authenticator app. ",
-    "TOTPVerify.ENTER_CODE": "Enter {length}-digit code"
+    "TOTPVerify.NEXT": "Next",
+    "TOTPVerify.VERIFY": "Use verification code from your authenticator app. "
 }


### PR DESCRIPTION
These will be migrated into the client/lang/en.js file and pushed to transifex next time translations are run.

The strings were automatically collected (and reordered to alphabetical order by keys) using [this POC branch of framework](https://github.com/creative-commoners/silverstripe-framework/commit/3b019c8e136ac6d1559d0497dc936255069727cf) wherein the textcollector is able to fetch strings from javascript.

## Issue
- https://github.com/silverstripe/silverstripe-totp-authenticator/issues/85