### PR TITLE
FIX Expose localisations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     },
     "extra": {
         "expose": [
-            "client/dist"
+            "client/dist",
+            "client/lang"
         ]
     },
     "minimum-stability": "dev",

--- a/src/Method.php
+++ b/src/Method.php
@@ -57,6 +57,7 @@ class Method implements MethodInterface
 
     public function applyRequirements(): void
     {
+        Requirements::add_i18n_javascript('silverstripe/totp-authenticator: client/lang');
         Requirements::javascript('silverstripe/totp-authenticator: client/dist/js/bundle.js');
         Requirements::css('silverstripe/totp-authenticator: client/dist/styles/bundle.css');
     }


### PR DESCRIPTION
Localisation files weren't exposed via composer vendor-expose, and also weren't being required via the requirements API. Because of this, only the default (English) strings were ever used.

## Issue
- https://github.com/silverstripe/silverstripe-totp-authenticator/issues/138