### PR TITLE
MNT Update behat test for sudo mode (backport)

### DIFF
--- a/tests/behat/features/mfa-totp.feature
+++ b/tests/behat/features/mfa-totp.feature
@@ -3,7 +3,8 @@ Feature: Use MFA TOTP
   I want to use MFA TOTP
 
    Background:
-    Given the "group" "EDITOR" has permissions "Access to 'Security' section"
+    Given I add an extension "SilverStripe\BehatExtension\Extensions\ActivateSudoModeServiceExtension" to the "SilverStripe\Security\SudoMode\SudoModeService" class
+    And the "group" "EDITOR" has permissions "Access to 'Security' section"
 
     # Login to create user and then logout
     And I am logged in as a member of "EDITOR" group


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/368

Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/13642912411/job/38136394491#step:12:458

Backport cherry-pick of https://github.com/silverstripe/silverstripe-totp-authenticator/pull/185

totp-authenticator isn't getting a new minor as part of CMS 5.4.0, so we need to update the behat test on the current minor branch
