### PR TITLE
DEP Conflict alpha version of mfa

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
         "silverstripe/standards": "^1",
         "phpstan/extension-installer": "^1.3"
     },
+    "conflict": {
+        "silverstripe/mfa": "<=6.0.0-alpha1"
+    },
     "autoload": {
         "psr-4": {
             "SilverStripe\\TOTP\\": "src/",


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/373

Fixes https://github.com/silverstripe/silverstripe-totp-authenticator/actions/runs/13687533446/job/38274283737#step:9:594 where mfa 6.0.0-alpha1 is being installed